### PR TITLE
fix imports

### DIFF
--- a/sunspec_exporter/sunspec_exporter.py
+++ b/sunspec_exporter/sunspec_exporter.py
@@ -49,8 +49,8 @@ try:
 except:
     import elementtree.ElementTree as ET
 import sunspec.core.pics as pics
-import sunspec.core.util as util
 from xml.dom import minidom
+import sys
 import time
 import re
 import collections


### PR DESCRIPTION
When running "query" command, this change will fix the error
```
Traceback (most recent call last):
  File "/sunspec_exporter/sunspec_exporter.py", line 323, in <module>
    sys.exit(0)
NameError: name 'sys' is not defined
```
Also removed an unused import.